### PR TITLE
fix: inference and analysis workflow bugs

### DIFF
--- a/saber/entry_points/inference_core.py
+++ b/saber/entry_points/inference_core.py
@@ -141,8 +141,9 @@ def segment_micrograph_core(
         pixel_size = 1
 
     # For now lets assume its always grayscale images
-    if image.ndim == 2:
-        out_image = segmenter.image[:,:,0]
+    out_image = segmenter.image
+    if out_image.ndim == 3:
+        out_image = out_image[:,:,0]
 
     # Write Run to Zarr
     input = os.path.splitext(os.path.basename(input))[0]

--- a/saber/entry_points/run_analysis.py
+++ b/saber/entry_points/run_analysis.py
@@ -24,7 +24,9 @@ def common_options(func):
         click.option("--run-ids", type=str, required=False, default=None,
                     help="Comma-separated list of RunIDs to process. If not provided, processes all RunIDs."),
         click.option("--n-procs", type=int, required=False, default=None,
-                    help="Number of Processes to Use for Parallelization.")
+                    help="Number of Processes to Use for Parallelization."),
+        click.option('-o', '--output', type=str, required=False, default='statistics.csv', 
+                    help='Path to Output CSV File.')
     ]
     for option in reversed(options):  # Add options in reverse order to preserve correct order
         func = option(func)
@@ -40,6 +42,7 @@ def process_organelles(
     n_procs: Optional[int],
     save_copick: bool = True,
     save_statistics: bool = True,
+    output: str = 'statistics.csv'
     ):
     """Core processing function that can be used by different commands."""
     import multiprocess as mp
@@ -54,7 +57,8 @@ def process_organelles(
         organelle_name, session_id, 
         user_id, run_ids,
         save_copick=save_copick,
-        save_statistics=save_statistics
+        save_statistics=save_statistics,
+        output=output
     )
 
     # Read Config File
@@ -79,7 +83,7 @@ def process_organelles(
     # Initialize CSV file if statistics are requested
     csv_filename = None
     if save_statistics:
-        csv_filename = f'{organelle_name}_statistics.csv'
+        csv_filename = output
         # Create CSV with headers
         with open(csv_filename, 'w', newline='') as csvfile:
             writer = csv.writer(csvfile)
@@ -157,7 +161,8 @@ def report_input_commands(
     organelle_name, session_id, 
     user_id, run_ids,
     save_copick=True,
-    save_statistics=True
+    save_statistics=True,
+    output: str = 'statistics.csv'
     ):
     """Print a summary of all inputs and processing options."""
     action_msg = []
@@ -174,7 +179,8 @@ def report_input_commands(
           f"\tVoxel Size: {voxel_size}\n"
           f"\tRun IDs: {run_ids if run_ids else 'All'}\n"
           f"\tSave to Copick: {save_copick}\n"
-          f"\tSave Statistics: {save_statistics}\n")
+          f"\tSave Statistics: {save_statistics}\n"
+          f"\tOutput: {output}\n")
 
 def pickable_object_check(root, organelle_name):
     """Check if the specified organelle exists as a pickable object in the config."""
@@ -192,7 +198,7 @@ def pickable_object_check(root, organelle_name):
 ########################################################
 
 
-@cli.command(context_settings=cli_context)
+@cli.command(context_settings=cli_context, no_args_is_help=True)
 @common_options
 @click.option("--save-statistics", default=True,
               help="Save statistics to Zarr file")
@@ -204,7 +210,8 @@ def coordinates(
     voxel_size: float,
     save_statistics: bool,
     run_ids: str,
-    n_procs: int
+    n_procs: int,
+    output: str
 ):
     if save_statistics: description = "Coordinates and Statistics Extraction"
     else: description = "Coordinate Extraction"
@@ -219,10 +226,11 @@ def coordinates(
         run_ids=run_ids,
         n_procs=n_procs,
         save_copick=True,
-        save_statistics=save_statistics
+        save_statistics=save_statistics,
+        output=output
     )
 
-@cli.command(context_settings=cli_context)
+@cli.command(context_settings=cli_context, no_args_is_help=True)
 @common_options
 def statistics(
     config: str,
@@ -231,7 +239,8 @@ def statistics(
     user_id: str,
     voxel_size: float,
     run_ids: str,
-    n_procs: int
+    n_procs: int,
+    output: str
 ):
     """Measure the size distribution of the measured organelles."""
     process_organelles(
@@ -243,7 +252,8 @@ def statistics(
         run_ids=run_ids,
         n_procs=n_procs,
         save_copick=False,
-        save_statistics=True
+        save_statistics=True,
+        output=output
     )
 
 @cli.command(context_settings=cli_context)
@@ -261,7 +271,8 @@ def slurm(
     run_ids: str,
     n_procs: int,
     save_copick: bool,
-    save_statistics: bool
+    save_statistics: bool,
+    output: str
     ):
     from saber.utils import slurm_submit
     import copick
@@ -280,7 +291,8 @@ def slurm(
         organelle_name, session_id, 
         user_id, run_ids,
         save_copick=save_copick,
-        save_statistics=save_statistics
+        save_statistics=save_statistics,
+        output=output
     )
     
     # Determine which command to use

--- a/saber/entry_points/run_tomogram_segment.py
+++ b/saber/entry_points/run_tomogram_segment.py
@@ -333,7 +333,7 @@ def slab(
               help="Number of slabs and spacing for multi-slab segmentation provided as thickness or thickness,spacing. (Default spacing is 30 if ignored)")
 def tomograms(
     config: str,
-    run_ids: str,
+    run_id: str,
     voxel_size: float,
     tomo_alg: str,
     seg_name: str,
@@ -351,7 +351,7 @@ def tomograms(
 
     print('🚀 Running Saber Tomogram Segmentation...')
     run_tomo_seg(
-        config, run_ids, voxel_size, tomo_alg,
+        config, run_id, voxel_size, tomo_alg,
         seg_name, seg_session_id, slab_thickness,
         model_config, model_weights, target_class, multi_slab, text_prompt
     )

--- a/saber/visualization/results.py
+++ b/saber/visualization/results.py
@@ -62,8 +62,15 @@ def save_slab_seg(
          classifier.display_mask_list(image, masks)
     plt.axis('off')
 
+    # Parse the current run string to extract runID and sessionID
+    output = current_run.split('-')
+    if len(output) == 2:
+        runID, sessionID = output
+    elif len(output) > 2:
+        runID = output[0]
+        sessionID = '-'.join(output[1:])
+
     # Save the Figure
-    runID, sessionID = current_run.split('-')
     os.makedirs(f'sID-{sessionID}/frames', exist_ok=True)
     plt.savefig(f'sID-{sessionID}/frames/{runID}.png', bbox_inches='tight', pad_inches=0)
     plt.close('all')


### PR DESCRIPTION
## Summary

Fixes several bugs in the inference and analysis workflows surfaced during user testing.

- **`inference_core.py`**: Fixed incorrect dimension check - the condition `image.ndim == 2` was guarding a 3D slice `[:,:,0]`, causing a crash on 2D images. Now correctly checks if the output is 3D before slicing.
- **`run_tomogram_segment.py`**: Fixed parameter name mismatch - `run_ids` was passed where the function expected `run_id`.
- **`results.py`**: Fixed a crash in `save_slab_seg` when a run string contains more than one `-` (e.g. `TS_001-0-1`). The split is now handled safely, joining any extra segments back into the session ID.
- **`run_analysis.py`**: Added `-o`/`--output` option to the `coordinates`, `statistics`, and `slurm` commands to allow users to specify the output CSV path (previously hardcoded as `{organelle_name}_statistics.csv`). Also added `no_args_is_help=True` to the `coordinates` and `statistics` commands.

## Acknowledgements

Thanks to @KatrinaABlack and @jowagner91 for identifying these bugs and providing recommendations for the fixes.